### PR TITLE
More fluent way to add multiple breadcrumb items

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,8 @@ An uber simple, "collection" style way to create breadcrumbs in `Laravel 5.1 <ht
  Usage
 ================================================================================
 
-Breadcrumbs are added to your controllers thus ``$breadcrumbs->add('/the/url', 'The Link Name');``
+Breadcrumbs are added to your controllers like this: ``$breadcrumbs->add('/the/url', 'The Link Name');``,
+or you can add multiple at once like this: ``$breadcrumbs->add(['/your-url' => 'Your Title', '/another/url'
+=> 'Another Title']);``.
 
 It is suggested that you add your index breadcrumb in the controller.

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -2,18 +2,50 @@
 
 namespace Snetty\LaravelSimpleBreadcrumbs;
 
-class Breadcrumbs extends \Illuminate\Support\Collection{
+use Illuminate\Support\Collection;
 
-	public static function start($url, $title){
-		return new self([(object) compact('url', 'title')]);
-	}
+class Breadcrumbs extends Collection
+{
+    /**
+     * Initialize the breadcrumbs.
+     *
+     * @param  string $url
+     * @param  string $title
+     * @return \Illuminate\Support\Collection
+     */
+    public static function start($url, $title)
+    {
+        return new self([(object) compact('url', 'title')]);
+    }
 
-	public function add($url, $title){
-		$this->push((object) compact('url', 'title'));
-		return $this;
-	}
+    /**
+     * Add one or more items to the breadcrumbs.
+     *
+     * @param string|array $urls
+     * @param string|void  $title
+     */
+    public function add($urls, $title = null)
+    {
+        if ( ! is_array($urls) && is_null($title) ) {
+            // It is not an array, add only one item.
+            $this->push((object) ['url' => $urls, 'title' => $title]);
+        } else {
+            // It is an array, add each of the items in the array.
+            foreach ($urls as $item => $title) {
+                $this->push((object) ['url' => $item, 'title' => $title]);
+            }
+        }
 
-	public function render(){
-		return view('vendor.snetty.laravel-simple-breadcrumbs.breadcrumbs', ['breadcrumbs' => $this])->render();
-	}
+        return $this;
+    }
+
+    /**
+     * Render the breadcrumbs on the page.
+     *
+     * @return \Illuminate\Contracts\View\Factory
+     */
+    public function render()
+    {
+        return view('vendor.snetty.laravel-simple-breadcrumbs.breadcrumbs', ['breadcrumbs' => $this])->render();
+    }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,13 +1,23 @@
-<?php 
+<?php
 
 namespace Snetty\LaravelSimpleBreadcrumbs;
 
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 
-class ServiceProvider extends LaravelServiceProvider {
-
+class ServiceProvider extends LaravelServiceProvider
+{
+    /**
+     * Whether or not to defer the registration.
+     *
+     * @var boolean
+     */
     protected $defer = true;
 
+    /**
+     * What services does the ServiceProviders provide?
+     *
+     * @return array
+     */
     public function provides()
     {
         return ['Snetty\LaravelSimpleBreadcrumbs\Breadcrumbs'];


### PR DESCRIPTION
This PR fixes some slight PSR-2 issues and provides a more fluent API by accepting an array in the `add()` method.

You can now do the following to add multiple items:

``` php
$breadcrumbs->add([
  'http://website.dev/home' => 'Home',
  'http://website.dev/tos' => 'Terms of Service'
]);
```

I also updated the documentation with this new information and added docblocks to all the methods :smile: 
